### PR TITLE
Apache configuration for Let's Encrypt webroot validation

### DIFF
--- a/docs/content/doc/usage/reverse-proxies.en-us.md
+++ b/docs/content/doc/usage/reverse-proxies.en-us.md
@@ -129,6 +129,8 @@ If you want Apache HTTPD to serve your Gitea instance, you can add the following
 
 Note: The following Apache HTTPD mods must be enabled: `proxy`, `proxy_http`
 
+If you wish to use Let's Encrypt with webroot validation, add the line `ProxyPass /.well-known !` before `ProxyPass` to disable proxying these requests to Gitea.
+
 ## Using Apache HTTPD with a sub-path as a reverse proxy
 
 In case you already have a site, and you want Gitea to share the domain name, you can setup Apache HTTPD to serve Gitea under a sub-path by adding the following to you Apache HTTPD configuration (usually located at `/etc/apache2/httpd.conf` in Ubuntu):


### PR DESCRIPTION
This PR originates from #9366. It might be helpful to include something in the docs to make it as easy as possible to implement SSL.

In this PR I simply added a note but you could alternatively add the line to the actual config block with a comment, or have a separate section/page going into more detail. 
